### PR TITLE
Allow blank lines in the description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ gherkin.peg.go: gherkin.peg
 	  -e 's/{{\([^}]*\)}}/{ p.\1 = buffer[begin:end] }/g' \
 	  > gherkin.peg.pp
 
-	$(peg) -inline gherkin.peg.pp
+	$(peg) -switch -inline gherkin.peg.pp
 
 	# dirty way to not export PEG specific types, constants or variables
 	cat gherkin.peg.pp.go | sed \

--- a/gherkin.peg
+++ b/gherkin.peg
@@ -15,7 +15,7 @@ Begin <-
 
 Feature <- 
   Tags 'Feature:' WS* <UntilLineEnd?>{{buf1}} <>{{buf2}} LineEnd
-  (WS* !('@' Word / 'Background:' / 'Scenario:' / 'Scenario Outline:' / !.) <UntilLineEnd?>{{++buf2}} LineEnd { p.buf2 = p.buf2 + "\n" })*
+  (WS* !('@' Word / 'Background:' / 'Scenario:' / 'Scenario Outline:') <UntilLineEnd?>{{++buf2}} LineEnd { p.buf2 = p.buf2 + "\n" })*
   { p.beginFeature(trimWS(p.buf1), trimWSML(p.buf2), p.buftags); p.buftags = nil }
   ( Background / Scenario / Outline / BlankLine )*
   { p.endFeature() }
@@ -101,7 +101,7 @@ UntilLineEnd <-
   ( EscapedChar / [^\n\\"#]+ / QuotedString )+
 
 LineEnd <- 
-  WS* LineComment? ( NL / !. )
+  WS* LineComment? NL
 
 LineComment <- 
   '#' < [^\n]* >

--- a/gherkin_parser.go
+++ b/gherkin_parser.go
@@ -1,6 +1,9 @@
 package gherkin
 
-import "github.com/muhqu/go-gherkin/events"
+import (
+	"github.com/muhqu/go-gherkin/events"
+	"strings"
+)
 
 type GherkinParser interface {
 	WithLogFn(LogFn)
@@ -11,6 +14,10 @@ type GherkinParser interface {
 }
 
 func NewGherkinParser(content string) GherkinParser {
+	if !strings.HasSuffix(content, "\n") {
+		content = content + "\n"
+	}
+
 	return &gherkinPegWrapper{gp: &gherkinPeg{Buffer: content}}
 }
 


### PR DESCRIPTION
Fixes #10.

This one took a while to track down. By making `UntilLineEnd` optional, everything up to `( NL / !. )` was optional. At EOF, `LineEnd` was repeatedly matching `!.` without advancing the pointer.

Unfortunately, [lookahead assertions are bugged with the `-switch` option](https://github.com/pointlander/peg/issues/33), ~~so I had to drop it to make this work~~.
